### PR TITLE
Changed Che spec rollout strategy to "Recreate"

### DIFF
--- a/apps/che/src/main/fabric8/deployment.yml
+++ b/apps/che/src/main/fabric8/deployment.yml
@@ -1,5 +1,7 @@
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   template:
     spec:
       containers:


### PR DESCRIPTION
Helps running `oc rollout latest che` safely 