### PR TITLE
CHE-179 Addded CHE_OAUTH_GITHUB_FORCEACTIVATION environment variable …

### DIFF
--- a/apps/che/src/main/fabric8/cm.yml
+++ b/apps/che/src/main/fabric8/cm.yml
@@ -9,3 +9,4 @@ data:
   docker-connector: "openshift"
   port: "8080"
   remote-debugging-enabled: "false"
+  che-oauth-github-forceactivation: "true"

--- a/apps/che/src/main/fabric8/deployment.yml
+++ b/apps/che/src/main/fabric8/deployment.yml
@@ -60,6 +60,11 @@ spec:
             configMapKeyRef:
               key: "remote-debugging-enabled"
               name: "che"
+        - name: "CHE_OAUTH_GITHUB_FORCEACTIVATION"
+          valueFrom:
+            configMapKeyRef:
+              key: "che-oauth-github-forceactivation"
+              name: "che"
         image: "rhche/che-server:cda3edc"
         imagePullPolicy: "IfNotPresent"
         name: che


### PR DESCRIPTION
Adds CHE_OAUTH_GITHUB_FORCEACTIVATION environment variable to deployment, allowing a GitHub oAuth token to be set without the requirement of having the GitHub Client ID and Client Secret values set.

See https://issues.jboss.org/browse/CHE-179