### PR TITLE
New configuration to make Che work on new int environment

### DIFF
--- a/apps/che/src/main/fabric8/cm.yml
+++ b/apps/che/src/main/fabric8/cm.yml
@@ -10,9 +10,9 @@ data:
   port: "8080"
   remote-debugging-enabled: "false"
   che-oauth-github-forceactivation: "true"
-  workspaces-memory-limit: "1500Mi"
+  workspaces-memory-limit: "1300Mi"
   workspaces-memory-request: "500Mi"
   enable-workspaces-autostart: "false"
-  che-server-java-opts: "-XX:+UseSerialGC -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=1000m -Xms256m"
-  che-workspaces-java-opts: "-XX:+UseSerialGC -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=1500m -Xms256m"
+  che-server-java-opts: "-XX:+UseSerialGC -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=700m -Xms256m"
+  che-workspaces-java-opts: "-XX:+UseSerialGC -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=1300m -Xms256m"
   

--- a/apps/che/src/main/fabric8/deployment.yml
+++ b/apps/che/src/main/fabric8/deployment.yml
@@ -90,7 +90,7 @@ spec:
             configMapKeyRef:
               key: "che-workspaces-java-opts"
               name: "che"
-        image: "rhche/che-server:cda3edc"
+        image: "rhche/che-server:e52a5a1"
         imagePullPolicy: "IfNotPresent"
         name: che
         readinessProbe:
@@ -105,7 +105,7 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            memory: 1Gi
+            memory: 700Mi
           requests:
             memory: 256Mi
         ports:


### PR DESCRIPTION
This setup has to be used when che workspaces are deployed as non-terminating pods (that's currently the only option)