### PR TITLE
Revert "Exposing che server route against https"

### DIFF
--- a/apps/che/src/main/fabric8/route.yml
+++ b/apps/che/src/main/fabric8/route.yml
@@ -4,5 +4,3 @@ spec:
   to:
     kind: Service
     name: "che-host"
-  tls:
-    termination: edge


### PR DESCRIPTION
Let's merge that to have a coherent template (che-server image and route with no support for https).