### PR TITLE
https support for Che (second try)

### DIFF
--- a/apps/che/src/main/fabric8/cm.yml
+++ b/apps/che/src/main/fabric8/cm.yml
@@ -15,4 +15,6 @@ data:
   enable-workspaces-autostart: "false"
   che-server-java-opts: "-XX:+UseSerialGC -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=700m -Xms256m"
   che-workspaces-java-opts: "-XX:+UseSerialGC -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=1300m -Xms256m"
+  che-openshift-secure-routes: "true"
+  che-secure-external-urls: "true"
   

--- a/apps/che/src/main/fabric8/deployment.yml
+++ b/apps/che/src/main/fabric8/deployment.yml
@@ -90,7 +90,17 @@ spec:
             configMapKeyRef:
               key: "che-workspaces-java-opts"
               name: "che"
-        image: "rhche/che-server:e52a5a1"
+        - name: "CHE_OPENSHIFT_SECURE_ROUTES"
+          valueFrom:
+            configMapKeyRef:
+              key: "che-openshift-secure-routes"
+              name: "che"
+        - name: "CHE_DOCKER_SERVER__EVALUATION__STRATEGY_SECURE_EXTERNAL_URLS"
+          valueFrom:
+            configMapKeyRef:
+              key: "che-secure-external-urls"
+              name: "che"
+        image: "rhche/che-server:56777e8"
         imagePullPolicy: "IfNotPresent"
         name: che
         readinessProbe:

--- a/apps/che/src/main/fabric8/route.yml
+++ b/apps/che/src/main/fabric8/route.yml
@@ -4,3 +4,5 @@ spec:
   to:
     kind: Service
     name: "che-host"
+  tls:
+    termination: edge


### PR DESCRIPTION
Updated version of Che, modified route to be secured and added properties to enable SSL