### PR TITLE
Mount workspace PVC in Che server

### DIFF
--- a/apps/che/src/main/fabric8/deployment.yml
+++ b/apps/che/src/main/fabric8/deployment.yml
@@ -126,8 +126,13 @@ spec:
         volumeMounts:
         - mountPath: "/data"
           name: "che-data-volume"
+        - mountPath: "/projects"
+          name: "claim-che-workspace"
       serviceAccountName: "che"
       volumes:
       - name: che-data-volume
         persistentVolumeClaim:
           claimName: che-data-volume
+      - name: claim-che-workspace
+        persistentVolumeClaim:
+          claimName: claim-che-workspace


### PR DESCRIPTION
Mount the PVC used for workspaces to the Che server to allow the server to create the directory that is mounted in the workspace. This is necessary because directories created by kubernetes when mounting a subpath are created with root permissions and cannot be modified by a non-root user. This allows us to create the required subdirectory directly, avoiding having to launch workspace pods twice in Che.

See: https://github.com/kubernetes/kubernetes/issues/41638