### PR TITLE
Add parameter for che subpath creation to configmap

### DIFF
--- a/apps/che/src/main/fabric8/cm.yml
+++ b/apps/che/src/main/fabric8/cm.yml
@@ -18,3 +18,4 @@ data:
   che-openshift-secure-routes: "true"
   che-secure-external-urls: "true"
   che-server-timeout-ms: "0"
+  che-openshift-precreate-subpaths: "false"

--- a/apps/che/src/main/fabric8/deployment.yml
+++ b/apps/che/src/main/fabric8/deployment.yml
@@ -105,6 +105,11 @@ spec:
             configMapKeyRef:
               key: "che-server-timeout-ms"
               name: "che"
+        - name: "CHE_OPENSHIFT_PRECREATE_WORKSPACE_DIRS"
+          valueFrom:
+            configMapKeyRef:
+              key: "che-openshift-precreate-subpaths"
+              name: "che"
         image: "rhche/che-server:${che-server.version}"
         imagePullPolicy: "IfNotPresent"
         name: che


### PR DESCRIPTION
Add parameter `che-openshift-precreate-subpaths` to configmap for Che. Setting it to false causes Che server to not run the workspace subpath creation job before launching a workspace, avoiding an unnecessary PV mount. OSIO includes the fix for https://github.com/kubernetes/kubernetes/issues/41638, so it can safely be set to false here.

Upstream Che PR: https://github.com/eclipse/che/pull/5008