### PR TITLE
Add configmap entries to disable workspace snapshots

### DIFF
--- a/apps/che/src/main/fabric8/cm.yml
+++ b/apps/che/src/main/fabric8/cm.yml
@@ -21,3 +21,4 @@ data:
   che-secure-external-urls: "true"
   che-server-timeout-ms: "3600000"
   che-openshift-precreate-subpaths: "false"
+  che-workspace-auto-snapshot: "false"

--- a/apps/che/src/main/fabric8/deployment.yml
+++ b/apps/che/src/main/fabric8/deployment.yml
@@ -120,6 +120,11 @@ spec:
             configMapKeyRef:
               key: "keycloak-github-endpoint"
               name: "che"
+        - name: "CHE_WORKSPACE_AUTO__SNAPSHOT"
+          valueFrom:
+            configMapKeyRef:
+              key: "che-workspace-auto-snapshot"
+              name: "che"
         image: "rhche/che-server:${che-server.version}"
         imagePullPolicy: "IfNotPresent"
         name: che


### PR DESCRIPTION
Che is by default taking "snapshots" of workspaces on shutdown. Adding the env var `CHE_WORKSPACE_AUTO__SNAPSHOT=false` disables this.

Issue: https://github.com/redhat-developer/rh-che/issues/109