### PR TITLE
Allow to always reload stacks from json file

### DIFF
--- a/apps/che/src/main/fabric8/cm.yml
+++ b/apps/che/src/main/fabric8/cm.yml
@@ -7,6 +7,7 @@ data:
   che-server-evaluation-strategy: "single-port"
   che.docker.server_evaluation_strategy.custom.template: "<serverName>-<if(isDevMachine)><workspaceIdWithoutPrefix><else><machineName><endif>-<externalAddress>"
   che.docker.server_evaluation_strategy.custom.external.protocol: "https"
+  che.predefined.stacks.reload_on_start: "true"
   log-level: "INFO"
   docker-connector: "openshift"
   port: "8080"

--- a/apps/che/src/main/fabric8/deployment.yml
+++ b/apps/che/src/main/fabric8/deployment.yml
@@ -50,6 +50,11 @@ spec:
             configMapKeyRef:
               key: "che.docker.server_evaluation_strategy.custom.external.protocol"
               name: "che"
+        - name: "CHE_PREDEFINED_STACKS_RELOAD__ON__START"
+          valueFrom:
+            configMapKeyRef:
+              key: "che.predefined.stacks.reload_on_start"
+              name: "che"
         - name: "CHE_LOG_LEVEL"
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
### What does this PR do?
Policy on loading stacks has been changed. In order to keep previous policy, a flag needs to be set

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/124

#### Changelog
Update policy for loading stacks.json file

Change-Id: Ia2afc2460e3d5892d9bd1e32f719fe785387b610
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>