### PR TITLE
rh-che 115: using '/api/system/state' for liveness & readiness probes

### DIFF
--- a/apps/che/src/main/fabric8/deployment.yml
+++ b/apps/che/src/main/fabric8/deployment.yml
@@ -144,13 +144,17 @@ spec:
         imagePullPolicy: "IfNotPresent"
         name: che
         readinessProbe:
-          tcpSocket:
+          httpGet:
+            path: /api/system/state
             port: 8080
-          initialDelaySeconds: 20
+            scheme: HTTP
+          initialDelaySeconds: 60
           timeoutSeconds: 10
         livenessProbe:
-          tcpSocket:
+          httpGet:
+            path: /api/system/state
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 120
           timeoutSeconds: 10
         resources:


### PR DESCRIPTION
@l0rd @mlabuda WDYT ?