### PR TITLE
rh-che-212: store logs of che-server in a persistent volume

### DIFF
--- a/apps/che/src/main/fabric8/cm.yml
+++ b/apps/che/src/main/fabric8/cm.yml
@@ -5,6 +5,7 @@ data:
   local-conf-dir: "/etc/conf"
   openshift-serviceaccountname: "che"
   che-server-evaluation-strategy: "docker-local-custom"
+  che.logs.dir: "/data/logs"
   che.docker.server_evaluation_strategy.custom.template: "<serverName>-<if(isDevMachine)><workspaceIdWithoutPrefix><else><machineName><endif>-<externalAddress>"
   che.docker.server_evaluation_strategy.custom.external.protocol: "https"
   che.predefined.stacks.reload_on_start: "true"

--- a/apps/che/src/main/fabric8/deployment.yml
+++ b/apps/che/src/main/fabric8/deployment.yml
@@ -16,6 +16,11 @@ spec:
             configMapKeyRef:
               key: "workspace-storage"
               name: "che"
+        - name: "CHE_LOGS_DIR"
+          valueFrom:
+            configMapKeyRef:
+              key: "che.logs.dir"
+              name: "che"
         - name: "CHE_WORKSPACE_STORAGE_CREATE_FOLDERS"
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
It will require https://github.com/redhat-developer/rh-che/pull/229 before merge

Change-Id: Ifad2b7e9e30642c9f3e472568063f06093abc716
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>