### PR TITLE
Setting keycloak oso / github endpoints in cm using template parameters

### DIFF
--- a/apps/che/src/main/fabric8/cm.yml
+++ b/apps/che/src/main/fabric8/cm.yml
@@ -17,8 +17,8 @@ data:
   workspaces-memory-limit: "2300Mi"
   workspaces-memory-request: "1500Mi"
   enable-workspaces-autostart: "false"
-  keycloak-oso-endpoint: "https://sso.openshift.io/auth/realms/fabric8/broker/openshift-v3/token"
-  keycloak-github-endpoint: "https://sso.openshift.io/auth/realms/fabric8/broker/github/token"
+  keycloak-oso-endpoint: ${KEYCLOAK_OSO_ENDPOINT}
+  keycloak-github-endpoint: ${KEYCLOAK_GITHUB_ENDPOINT}
   keycloak-disabled: "false"
   che-server-java-opts: "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=700m -Xms256m"
   che-workspaces-java-opts: "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=1300m -Xms256m"

--- a/packages/fabric8-online-che/src/main/fabric8/template.yml
+++ b/packages/fabric8-online-che/src/main/fabric8/template.yml
@@ -8,3 +8,7 @@ parameters:
 - name: RECOMMENDER_API_TOKEN
 - name: DOMAIN
   value: d800.free-int.openshiftapps.com
+- name: KEYCLOAK_OSO_ENDPOINT
+  value: https://sso.prod-preview.openshift.io/auth/realms/fabric8/broker/openshift-v3/token
+- name: KEYCLOAK_GITHUB_ENDPOINT
+  value: https://sso.prod-preview.openshift.io/auth/realms/fabric8/broker/github/token


### PR DESCRIPTION
NOTE: prod-preview keycloak endpoints are used by default